### PR TITLE
Add public wikis as git (Wikipedia...)

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,6 +64,16 @@
 
 ---
 
+| | Wikis as Git |
+| - | - |
+| **Description** | Public Wikis as git: Wikipedia, ... |
+| ***Init&Run*** | `ipfs-cluster-follow wikis-as-git run --init wikis-as-git.collab.ipfscluster.io` |
+| **Size** | unknown (import is still running) |
+| **Cluster version** | 1.0.1 |
+| **Hosted by** | @RubenKelevra |
+
+---
+
 | | Wikipedia |
 | - | - | 
 | **Description** | Snapshots of Wikipedia articles for various languages |

--- a/index.md
+++ b/index.md
@@ -20,17 +20,6 @@
 
 ---
 
-| | [Project Gutenberg (Spanish)](https://gutenberg.org) |
-| - | - |
-| **Description** | Spanish eBooks from Project Gutenberg, in HTML format. |
-| ***Init&Run*** | `ipfs-cluster-follow gutenberg_es run --init gutenberg-es.collab.ipfscluster.io` |
-| **Size** | 1GB |
-| **Cluster version** | 1.0.0-rc3 |
-| **Hosted by** | Protocol Labs |
-| **Tooling** | [gutenberg-to-ipfs repository](https://github.com/ipfs-shipyard/gutenberg-to-ipfs) |
-
----
-
 | | IPFS Websites |
 | - | - |
 | **Description** | A collection of IPFS-related websites (ipfs.io, dist.ipfs.io, libp2p.io, docs.ipfs.io...) |
@@ -51,6 +40,17 @@
 | **Hosted by** | @RubenKelevra |
 | **How-To Use** | [Introduction](https://github.com/RubenKelevra/pacman.store/blob/master/README.md#pacmanstore) |
 | **Tooling** | [pacman.store toolset](https://github.com/RubenKelevra/rsync2ipfs-cluster) |
+
+---
+
+| | [Project Gutenberg (Spanish)](https://gutenberg.org) |
+| - | - |
+| **Description** | Spanish eBooks from Project Gutenberg, in HTML format. |
+| ***Init&Run*** | `ipfs-cluster-follow gutenberg_es run --init gutenberg-es.collab.ipfscluster.io` |
+| **Size** | 1GB |
+| **Cluster version** | 1.0.0-rc3 |
+| **Hosted by** | Protocol Labs |
+| **Tooling** | [gutenberg-to-ipfs repository](https://github.com/ipfs-shipyard/gutenberg-to-ipfs) |
 
 ---
 


### PR DESCRIPTION
Hey @hsanjuan,

is it possible to get a key for ipns on wikis-as-git.collab.ipfscluster.io for this?

If yes, can we do this in general, to avoid having to create a domain for every single collab cluster - like adding the zone file to git, to allow to make the changes (and the admin just imports them after merge?) :)